### PR TITLE
Fix/filter counts test location

### DIFF
--- a/test/client/src/utils/filter/genTagValueCounts.spec.js
+++ b/test/client/src/utils/filter/genTagValueCounts.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 
-const genTagValueCounts = require('../../../../client/src/utils/filter/genTagValueCounts');
+const genTagValueCounts = require('../../../../../client/src/utils/filter/genTagValueCounts');
 
 describe('client > src > utils > filter > genTagValueCounts', function () {
   const testApps = [


### PR DESCRIPTION
Changed the location of the genTagValueCounts.spec.js to correct directory path